### PR TITLE
requirements uses the right branch of transformers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ huggingface-hub==0.7.0
 datasets==2.3.2
 scikit-learn==1.1.1
 torch==1.11.0
-transformers==4.20.0
+transformers @ git+https://github.com/bigcode-project/transformers.git@multi_query
 umap-learn==0.5.3


### PR DESCRIPTION
Updated requirements.txt to use our custom fork of transformers, at the branch containing multi-query attention

Edit : meant to fix #20 